### PR TITLE
Trim records in the scheduler table

### DIFF
--- a/api/src/main/resources/_core/compiler/linux/compile-mysql.sh
+++ b/api/src/main/resources/_core/compiler/linux/compile-mysql.sh
@@ -291,6 +291,26 @@ CREATE EVENT IF NOT EXISTS _mamba_etl_scheduler_event
     DO CALL sp_mamba_etl_schedule();
 
 ~-~-
+
+-- Setup a trigger that trims record off _mamba_etl_schedule to just leave 20 latest records.
+-- to avoid the table growing too big
+
+ CREATE TRIGGER _mamba_etl_scheduler_trim_log_table
+     AFTER INSERT ON _mamba_etl_schedule
+     FOR EACH ROW
+ BEGIN
+     DELETE FROM _mamba_etl_schedule
+     WHERE id NOT IN (
+         SELECT id FROM (
+                            SELECT id
+                            FROM _mamba_etl_schedule
+                            ORDER BY id DESC
+                                LIMIT 20
+                        ) AS recent_records
+     );
+ END;
+
+ ~-~-
 "
 }
 

--- a/api/src/main/resources/_core/compiler/linux/compile-mysql.sh
+++ b/api/src/main/resources/_core/compiler/linux/compile-mysql.sh
@@ -295,18 +295,18 @@ CREATE EVENT IF NOT EXISTS _mamba_etl_scheduler_event
 -- Setup a trigger that trims record off _mamba_etl_schedule to just leave 20 latest records.
 -- to avoid the table growing too big
 
- CREATE TRIGGER _mamba_etl_scheduler_trim_log_table
-     AFTER INSERT ON _mamba_etl_schedule
-     FOR EACH ROW
+ CREATE EVENT IF NOT EXISTS _mamba_etl_scheduler_trim_log_event
+ ON SCHEDULE EVERY 3 HOUR -- Adjust the schedule as needed
+ DO
  BEGIN
      DELETE FROM _mamba_etl_schedule
      WHERE id NOT IN (
          SELECT id FROM (
-                            SELECT id
-                            FROM _mamba_etl_schedule
-                            ORDER BY id DESC
-                                LIMIT 20
-                        ) AS recent_records
+             SELECT id
+             FROM _mamba_etl_schedule
+             ORDER BY id DESC
+             LIMIT 20
+         ) AS recent_records
      );
  END;
 

--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_scheduler_wrapper.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_scheduler_wrapper.sql
@@ -26,7 +26,6 @@ BEGIN
         CALL sp_mamba_data_processing_increment_and_flatten();
     END IF;
 
-    CALL sp_mamba_data_processing_etl(incremental_mode_cascaded);
 
 END //
 


### PR DESCRIPTION
The log file might grow too big, this is to trim it down.