### PR TITLE
Fixes stored procedure creation issues in SQL scripts

### DIFF
--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_flat_table_obs_group/sp_mamba_flat_encounter_obs_group_table_create.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_flat_table_obs_group/sp_mamba_flat_encounter_obs_group_table_create.sql
@@ -1,6 +1,6 @@
-DELIMITER //
-
 DROP PROCEDURE IF EXISTS `sp_mamba_flat_encounter_obs_group_table_create`;
+
+DELIMITER //
 
 CREATE PROCEDURE `sp_mamba_flat_encounter_obs_group_table_create`(
     IN `flat_encounter_table_name` VARCHAR(60) CHARSET UTF8MB4,

--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_flat_table_obs_group/sp_mamba_flat_encounter_obs_group_table_create_all.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_flat_table_obs_group/sp_mamba_flat_encounter_obs_group_table_create_all.sql
@@ -1,7 +1,7 @@
 -- Flatten all Encounters given in Config folder
-DELIMITER //
-
 DROP PROCEDURE IF EXISTS sp_mamba_flat_encounter_obs_group_table_create_all;
+
+DELIMITER //
 
 CREATE PROCEDURE sp_mamba_flat_encounter_obs_group_table_create_all()
 BEGIN

--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_flat_table_obs_group/sp_mamba_flat_encounter_obs_group_table_insert.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_flat_table_obs_group/sp_mamba_flat_encounter_obs_group_table_insert.sql
@@ -1,7 +1,6 @@
+DROP PROCEDURE IF EXISTS sp_mamba_flat_encounter_obs_group_table_insert;
 
 DELIMITER //
-
-DROP PROCEDURE IF EXISTS sp_mamba_flat_encounter_obs_group_table_insert;
 
 CREATE PROCEDURE sp_mamba_flat_encounter_obs_group_table_insert(
     IN flat_encounter_table_name VARCHAR(60) CHARACTER SET UTF8MB4,

--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_flat_table_obs_group/sp_mamba_flat_encounter_obs_group_table_insert_all.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_flat_table_obs_group/sp_mamba_flat_encounter_obs_group_table_insert_all.sql
@@ -1,7 +1,7 @@
 -- Flatten all Encounters given in Config folder
-DELIMITER //
-
 DROP PROCEDURE IF EXISTS sp_mamba_flat_encounter_obs_group_table_insert_all;
+
+DELIMITER //
 
 CREATE PROCEDURE sp_mamba_flat_encounter_obs_group_table_insert_all()
 BEGIN


### PR DESCRIPTION
Ensures proper inclusion of DELIMITER statements for stored procedures. Resolves problems with missing procedures during execution of create_stored_procedures.sql.

Addresses issue with the following procedures:
- sp_mamba_flat_encounter_obs_group_table_create
- sp_mamba_flat_encounter_obs_group_table_create_all
- sp_mamba_flat_encounter_obs_group_table_insert
- sp_mamba_flat_encounter_obs_group_table_insert_all

https://github.com/openmrs/openmrs-module-mamba-core/issues/198