### PR TITLE
This update modifies the unstuck schedule stored procedure to improve…

### DIFF
--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_schedule.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_schedule.sql
@@ -33,8 +33,8 @@ BEGIN
 
  IF etl_is_ready_to_run THEN
 
- SET time_now = UTC_TIMESTAMP();
- SET start_time_seconds = TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', time_now);
+ SET time_now = NOW();
+ SET start_time_seconds = UNIX_TIMESTAMP(time_now);
 
  INSERT INTO _mamba_etl_schedule(start_time, transaction_status)
  VALUES (time_now, 'RUNNING');
@@ -50,8 +50,8 @@ BEGIN
  -- Call ETL
  CALL sp_mamba_etl_scheduler_wrapper();
 
- SET txn_end_time = UTC_TIMESTAMP();
- SET end_time_seconds = TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', txn_end_time);
+ SET txn_end_time = NOW();
+ SET end_time_seconds = UNIX_TIMESTAMP(txn_end_time);
 
  SET time_taken = (end_time_seconds - start_time_seconds);
 
@@ -62,12 +62,12 @@ BEGIN
  LIMIT 1);
 
  SET next_schedule_seconds = start_time_seconds + interval_seconds + etl_execution_delay_seconds;
- SET next_schedule_time = TIMESTAMPADD(SECOND, next_schedule_seconds, '1970-01-01 00:00:00');
+ SET next_schedule_time = FROM_UNIXTIME(next_schedule_seconds);
 
  -- Run ETL immediately if schedule was missed (give allowance of 1 second)
  IF end_time_seconds > next_schedule_seconds THEN
  SET missed_schedule_seconds = end_time_seconds - next_schedule_seconds;
- SET next_schedule_time = TIMESTAMPADD(SECOND, (end_time_seconds + 1), '1970-01-01 00:00:00');
+ SET next_schedule_time = FROM_UNIXTIME(end_time_seconds + 1);
  END IF;
 
  UPDATE _mamba_etl_schedule

--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_un_stuck_scheduler.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_un_stuck_scheduler.sql
@@ -5,30 +5,53 @@ DELIMITER //
 CREATE PROCEDURE sp_mamba_etl_un_stuck_scheduler()
 BEGIN
 
- DECLARE running_schedule_record BOOLEAN DEFAULT FALSE;
- DECLARE no_running_mamba_sp BOOLEAN DEFAULT FALSE;
- DECLARE last_schedule_record_id INT;
+    DECLARE running_schedule_record BOOLEAN DEFAULT FALSE;
+    DECLARE no_running_mamba_sp BOOLEAN DEFAULT FALSE;
+    DECLARE last_schedule_record_id INT;
+    DECLARE end_time DATETIME DEFAULT DATE_ADD(NOW(),INTERVAL -5 YEAR );
+    DECLARE error_schedule BOOLEAN DEFAULT FALSE;
 
- SET running_schedule_record = (SELECT COALESCE(
- (SELECT IF(transaction_status = 'RUNNING'
-  AND completion_status is null,
- TRUE, FALSE)
- FROM _mamba_etl_schedule
- ORDER BY id DESC
- LIMIT 1), TRUE));
- SET no_running_mamba_sp = NOT EXISTS (SELECT 1
- FROM performance_schema.events_statements_current
- WHERE SQL_TEXT LIKE 'CALL sp_mamba_etl_scheduler_wrapper(%'
- OR SQL_TEXT = 'CALL sp_mamba_etl_scheduler_wrapper()');
- IF running_schedule_record AND no_running_mamba_sp THEN
- SET last_schedule_record_id = (SELECT MAX(id) FROM _mamba_etl_schedule limit 1);
- UPDATE _mamba_etl_schedule
- SET end_time = NOW(),
- completion_status = 'SUCCESS',
- transaction_status = 'COMPLETED',
- success_or_error_message = 'Stuck schedule updated'
- WHERE id = last_schedule_record_id;
- END IF;
+    SET last_schedule_record_id = (SELECT MAX(id) FROM _mamba_etl_schedule limit 1);
+    SET running_schedule_record = (SELECT COALESCE(
+                                                  (SELECT IF(transaction_status = 'RUNNING'
+                                                                 AND completion_status is null,
+                                                             TRUE, FALSE)
+                                                   FROM _mamba_etl_schedule
+                                                   WHERE id = last_schedule_record_id), FALSE));
+    SET error_schedule = (SELECT COALESCE(
+                                         (SELECT IF(transaction_status = 'COMPLETED'
+                                                        AND completion_status = 'ERROR',
+                                                    TRUE, FALSE)
+                                          FROM _mamba_etl_schedule
+                                          WHERE id = last_schedule_record_id), FALSE));
+    SET no_running_mamba_sp = NOT EXISTS (SELECT 1
+                                          FROM performance_schema.events_statements_current
+                                          WHERE SQL_TEXT LIKE 'CALL sp_mamba_etl_scheduler_wrapper(%'
+                                             OR SQL_TEXT = 'CALL sp_mamba_etl_scheduler_wrapper()');
+    SET end_time = (SELECT start_time
+                    FROM _mamba_etl_schedule sch
+                    WHERE end_time IS NOT NULL
+                      AND transaction_status = 'COMPLETED'
+                      AND completion_status = 'SUCCESS'
+                      AND success_or_error_message is null
+                    ORDER BY id DESC
+                    LIMIT 1);
+
+    IF running_schedule_record AND no_running_mamba_sp AND NOT error_schedule THEN
+    UPDATE _mamba_etl_schedule
+    SET end_time                 = end_time,
+        completion_status        = 'SUCCESS',
+        transaction_status       = 'COMPLETED',
+        success_or_error_message = 'Stuck schedule updated'
+    WHERE id = last_schedule_record_id;
+    ELSEIF error_schedule THEN
+    UPDATE _mamba_etl_schedule
+    SET end_time                 = end_time,
+        completion_status        = 'SUCCESS',
+        transaction_status       = 'COMPLETED',
+        success_or_error_message = 'Error schedule updated'
+    WHERE id = last_schedule_record_id;
+    END IF;
 
 END //
 

--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_un_stuck_scheduler.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_un_stuck_scheduler.sql
@@ -8,7 +8,7 @@ BEGIN
     DECLARE running_schedule_record BOOLEAN DEFAULT FALSE;
     DECLARE no_running_mamba_sp BOOLEAN DEFAULT FALSE;
     DECLARE last_schedule_record_id INT;
-    DECLARE end_time DATETIME DEFAULT DATE_ADD(NOW(),INTERVAL -5 YEAR );
+    DECLARE incremental_start_time DATETIME DEFAULT DATE_ADD(NOW(),INTERVAL -5 YEAR );
     DECLARE error_schedule BOOLEAN DEFAULT FALSE;
 
     SET last_schedule_record_id = (SELECT MAX(id) FROM _mamba_etl_schedule limit 1);
@@ -28,9 +28,9 @@ BEGIN
                                           FROM performance_schema.events_statements_current
                                           WHERE SQL_TEXT LIKE 'CALL sp_mamba_etl_scheduler_wrapper(%'
                                              OR SQL_TEXT = 'CALL sp_mamba_etl_scheduler_wrapper()');
-    SET end_time = (SELECT start_time
+    SET incremental_start_time = (SELECT start_time
                     FROM _mamba_etl_schedule sch
-                    WHERE end_time IS NOT NULL
+                    WHERE incremental_start_time IS NOT NULL
                       AND transaction_status = 'COMPLETED'
                       AND completion_status = 'SUCCESS'
                       AND success_or_error_message is null
@@ -39,14 +39,16 @@ BEGIN
 
     IF running_schedule_record AND no_running_mamba_sp AND NOT error_schedule THEN
     UPDATE _mamba_etl_schedule
-    SET end_time                 = end_time,
+    SET end_time                 = incremental_start_time,
+        start_time               = incremental_start_time,
         completion_status        = 'SUCCESS',
         transaction_status       = 'COMPLETED',
         success_or_error_message = 'Stuck schedule updated'
     WHERE id = last_schedule_record_id;
     ELSEIF error_schedule THEN
     UPDATE _mamba_etl_schedule
-    SET end_time                 = end_time,
+    SET end_time                 = incremental_start_time,
+        start_time               = incremental_start_time,
         completion_status        = 'SUCCESS',
         transaction_status       = 'COMPLETED',
         success_or_error_message = 'Error schedule updated'

--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_un_stuck_scheduler.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_un_stuck_scheduler.sql
@@ -8,7 +8,7 @@ BEGIN
     DECLARE running_schedule_record BOOLEAN DEFAULT FALSE;
     DECLARE no_running_mamba_sp BOOLEAN DEFAULT FALSE;
     DECLARE last_schedule_record_id INT;
-    DECLARE incremental_start_time DATETIME DEFAULT DATE_ADD(NOW());
+    DECLARE incremental_start_time DATETIME DEFAULT NOW();
     DECLARE error_schedule BOOLEAN DEFAULT FALSE;
 
     SET last_schedule_record_id = (SELECT MAX(id) FROM _mamba_etl_schedule limit 1);

--- a/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_un_stuck_scheduler.sql
+++ b/api/src/main/resources/_core/database/mysql/xf_system/etl_scheduler/sp_mamba_etl_un_stuck_scheduler.sql
@@ -8,7 +8,7 @@ BEGIN
     DECLARE running_schedule_record BOOLEAN DEFAULT FALSE;
     DECLARE no_running_mamba_sp BOOLEAN DEFAULT FALSE;
     DECLARE last_schedule_record_id INT;
-    DECLARE incremental_start_time DATETIME DEFAULT DATE_ADD(NOW(),INTERVAL -5 YEAR );
+    DECLARE incremental_start_time DATETIME DEFAULT DATE_ADD(NOW());
     DECLARE error_schedule BOOLEAN DEFAULT FALSE;
 
     SET last_schedule_record_id = (SELECT MAX(id) FROM _mamba_etl_schedule limit 1);


### PR DESCRIPTION
… data integrity and fix stuck rows.

** The procedure now copies the start time from the last known successful schedule and applies it to the stuck row. This prevents data loss that could occur between the time of the last successful schedule and when the unstuck procedure is executed.

** Additionally, this change extends the same unstuck logic to handle schedule outcomes that resulted in an error, ensuring those rows are also corrected properly.