### PR TITLE
feat: add external ETL directory support with transaction management

### DIFF
--- a/api/src/main/java/org/openmrs/module/mambacore/api/dao/impl/JdbcFlattenDatabaseDao.java
+++ b/api/src/main/java/org/openmrs/module/mambacore/api/dao/impl/JdbcFlattenDatabaseDao.java
@@ -9,15 +9,19 @@ import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -34,20 +38,110 @@ public class JdbcFlattenDatabaseDao implements FlattenDatabaseDao {
 
         MambaETLProperties props = MambaETLProperties.getInstance();
         log.info("Deploying MambaETL, scheduled @interval: " + props.getInterval() + " seconds...");
-        executeSqlScript(props);
-        log.info("Done deploying MambaETL...");
+
+        try {
+            if (props.isUseExternalEtl()) {
+                // External mode: Auto-discover and deploy all SQL files in the external directory
+                try {
+                    deployFromExternalDirectory(props);
+                } catch (IOException e) {
+                    log.error("Failed to deploy ETL from external directory: {}", props.getEtlDirectoryPath(), e);
+                    // Fall back to internal mode on external failure
+                    log.warn("Falling back to internal mode due to external directory failure");
+                    deployFromClasspath(props);
+                }
+            } else {
+                // Internal mode: Use the default classpath resource
+                deployFromClasspath(props);
+            }
+            log.info("Done deploying MambaETL...");
+        } catch (RuntimeException e) {
+            log.error("Failed to deploy MambaETL", e);
+            throw e;
+        }
     }
 
-    private void executeSqlScript(MambaETLProperties props) {
+    private void deployFromClasspath(MambaETLProperties props) {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-
         try (InputStream stream = classLoader.getResourceAsStream(ETL_DEPLOY_SQL)) {
 
             if (stream == null) {
-                log.error("SQL script not found: {}", ETL_DEPLOY_SQL);
-                return;
+                log.error("SQL script not found in classpath: {}", ETL_DEPLOY_SQL);
+                throw new RuntimeException("SQL script not found in classpath: " + ETL_DEPLOY_SQL);
             }
 
+            log.info("Loading ETL script from classpath resource: {}", ETL_DEPLOY_SQL);
+            executeSqlScript(stream, props);
+        } catch (IOException e) {
+            log.error("IOException while reading classpath script", e);
+            throw new RuntimeException("Failed to deploy ETL from classpath", e);
+        }
+    }
+
+    private void deployFromExternalDirectory(MambaETLProperties props) throws IOException {
+        String etlDirectoryPath = props.getEtlDirectoryPath();
+        log.info("External ETL mode enabled, scanning directory: {}", etlDirectoryPath);
+
+        // Discover all SQL files in the external directory
+        List<Path> sqlFiles = discoverSqlFiles(etlDirectoryPath, props);
+
+        if (sqlFiles.isEmpty()) {
+            log.warn("No SQL files found in external directory: {}, falling back to internal mode", etlDirectoryPath);
+            throw new IOException("No SQL files found in external ETL directory: " + etlDirectoryPath);
+        }
+
+        log.info("Found {} SQL file(s) in external directory", sqlFiles.size());
+
+        // Deploy each SQL file
+        int successCount = 0;
+        int failureCount = 0;
+        for (Path sqlFile : sqlFiles) {
+            log.info("Deploying ETL script: {}", sqlFile.getFileName());
+            try (InputStream stream = Files.newInputStream(sqlFile)) {
+                executeSqlScript(stream, props);
+                successCount++;
+            } catch (IOException e) {
+                failureCount++;
+                log.error("Error processing SQL file: {}", sqlFile, e);
+            } catch (RuntimeException e) {
+                failureCount++;
+                log.error("Error executing SQL script: {}", sqlFile, e);
+            }
+        }
+
+        if (failureCount > 0) {
+            log.warn("ETL deployment completed with {} successes and {} failures", successCount, failureCount);
+        }
+    }
+
+    private List<Path> discoverSqlFiles(String directoryPath, MambaETLProperties props) throws IOException {
+        List<Path> sqlFiles = new ArrayList<>();
+        Path directory = Paths.get(directoryPath);
+
+        if (!Files.exists(directory) || !Files.isDirectory(directory)) {
+            log.warn("External ETL directory does not exist or is not a directory: {}", directoryPath);
+            return sqlFiles;
+        }
+
+        // Find all .sql files in the directory (configurable maxDepth with default of 5)
+        int maxDepth = props.getEtlDiscoveryDepth();
+        try {
+            Files.walk(directory, maxDepth)
+                    .filter(Files::isRegularFile)
+                    .filter(path -> {
+                        String pathStr = path.toString();
+                        return pathStr.toLowerCase().endsWith(".sql");
+                    })
+                    .forEach(sqlFiles::add);
+        } catch (java.nio.file.FileSystemLoopException e) {
+            log.warn("Symbolic link cycle detected in ETL directory, skipping affected paths: {}", directoryPath, e);
+        }
+
+        return sqlFiles;
+    }
+
+    private void executeSqlScript(InputStream stream, MambaETLProperties props) {
+        try {
             Map<String, String> replacements = new HashMap<>();
             replacements.put("mamba_source_db", props.getOpenmrsDatabase());
             replacements.put("mamba_etl_db", props.getEtlDatababase());
@@ -56,25 +150,63 @@ public class JdbcFlattenDatabaseDao implements FlattenDatabaseDao {
 
             try (BufferedReader reader = Files.newBufferedReader(modifiedEtlSqlFile, StandardCharsets.UTF_8)) {
                 String sqlScript = reader.lines()
-                        .collect(Collectors.joining("\n"));
-                        //.replaceAll(MYSQL_COMMENT_REGEX, "");
+                        .collect(Collectors.joining("\n"))
+                        .replaceAll(MYSQL_COMMENT_REGEX, "");
 
                 DataSource dataSource = ConnectionPoolManager
                         .getInstance()
                         .getDefaultDataSource();
 
                 try (Connection connection = dataSource.getConnection()) {
-                    executeStatements(connection, sqlScript, props);
+                    // Disable auto-commit to manage transaction explicitly
+                    boolean originalAutoCommit;
+                    try {
+                        originalAutoCommit = connection.getAutoCommit();
+                        connection.setAutoCommit(false);
+                    } catch (SQLException e) {
+                        log.error("Failed to configure transaction auto-commit", e);
+                        throw new RuntimeException("Failed to configure transaction for SQL execution", e);
+                    }
+
+                    SQLException executionError = null;
+                    try {
+                        executeStatements(connection, sqlScript, props);
+                        connection.commit();
+                        log.info("SQL script executed successfully");
+                    } catch (SQLException e) {
+                        executionError = e;
+                        log.error("SQLException while executing script, rolling back", e);
+                        // Attempt rollback but don't let its failure hide the original error
+                        try {
+                            connection.rollback();
+                        } catch (SQLException rollbackEx) {
+                            log.warn("Rollback failed after SQL execution error: {}", rollbackEx.getMessage(), rollbackEx);
+                        }
+                        throw new RuntimeException("SQL execution failed, transaction rolled back", executionError);
+                    } finally {
+                        // Restore auto-commit, don't let exceptions here suppress the original
+                        try {
+                            connection.setAutoCommit(originalAutoCommit);
+                        } catch (SQLException e) {
+                            log.warn("Failed to restore auto-commit state", e);
+                        }
+                    }
                 } catch (SQLException e) {
-                    log.error("SQLException while executing script", e);
+                    log.error("SQLException while obtaining database connection", e);
+                    throw new RuntimeException("Failed to establish database connection for transaction", e);
                 }
             } catch (IOException e) {
                 log.error("Error reading temporary file", e);
             } finally {
-                Files.deleteIfExists(modifiedEtlSqlFile);
+                try {
+                    Files.deleteIfExists(modifiedEtlSqlFile);
+                } catch (IOException e) {
+                    log.warn("Failed to delete temporary file: {}", modifiedEtlSqlFile, e);
+                }
             }
         } catch (IOException e) {
             log.error("IOException while reading script", e);
+            throw new RuntimeException("Failed to execute SQL script", e);
         }
     }
 

--- a/api/src/main/java/org/openmrs/module/mambacore/util/MambaETLProperties.java
+++ b/api/src/main/java/org/openmrs/module/mambacore/util/MambaETLProperties.java
@@ -1,7 +1,10 @@
 package org.openmrs.module.mambacore.util;
 
 import org.openmrs.api.context.Context;
+import org.openmrs.util.OpenmrsUtil;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Properties;
 
 public class MambaETLProperties {
@@ -34,6 +37,15 @@ public class MambaETLProperties {
 	
 	private final int connectionMaxTotal = 20;
 	
+	// External ETL configuration properties
+	private final String etlDirectory;
+	
+	private boolean useExternalEtl;
+	
+	private String etlDirectoryPath;
+	
+	private final int etlDiscoveryDepth;
+	
 	private MambaETLProperties() {
 		
 		Properties properties = Context.getRuntimeProperties();
@@ -54,6 +66,44 @@ public class MambaETLProperties {
 		this.incremental = getIntProperty(properties, "mambaetl.analysis.incremental_mode", 1);
 		this.automated = getIntProperty(properties, "mambaetl.analysis.automated_flattening", 0);
 		this.interval = getIntProperty(properties, "mambaetl.analysis.etl_interval", 300);
+		
+		// External ETL configuration
+		this.etlDiscoveryDepth = getIntProperty(properties, "mambaetl.analysis.etl_discovery_depth", 5);
+		this.etlDirectory = getProperty(properties, "mambaetl.analysis.etl_directory", "");
+		
+		// Determine if we should use external ETL directory
+		// External mode is enabled when etlDirectory is configured
+		this.useExternalEtl = !this.etlDirectory.isEmpty();
+		
+		// Resolve directory path (supports relative to appdata or absolute)
+		if (this.useExternalEtl) {
+			File dir = new File(this.etlDirectory);
+			if (!dir.isAbsolute()) {
+				// Relative to application data directory + configuration/
+				try {
+					File appDataDir = new File(OpenmrsUtil.getApplicationDataDirectory());
+					File configDir = new File(appDataDir, "configuration");
+					this.etlDirectoryPath = new File(configDir, this.etlDirectory).getAbsolutePath();
+				}
+				catch (Exception e) {
+					// If application data directory cannot be determined, disable external mode
+					this.useExternalEtl = false;
+					this.etlDirectoryPath = "";
+				}
+			} else {
+				// Sanitize path to prevent traversal outside intended directory
+				try {
+					this.etlDirectoryPath = dir.getCanonicalPath();
+				}
+				catch (IOException e) {
+					// If path cannot be canonicalized, disable external mode
+					this.useExternalEtl = false;
+					this.etlDirectoryPath = "";
+				}
+			}
+		} else {
+			this.etlDirectoryPath = "";
+		}
 	}
 	
 	public static synchronized MambaETLProperties getInstance() {
@@ -113,6 +163,22 @@ public class MambaETLProperties {
 	
 	public int getConnectionMaxTotal() {
 		return connectionMaxTotal;
+	}
+	
+	public String getEtlDirectory() {
+		return etlDirectory;
+	}
+	
+	public boolean isUseExternalEtl() {
+		return useExternalEtl;
+	}
+	
+	public String getEtlDirectoryPath() {
+		return etlDirectoryPath;
+	}
+	
+	public int getEtlDiscoveryDepth() {
+		return etlDiscoveryDepth;
 	}
 	
 	private String getProperty(Properties properties, String key, String defaultValue) {


### PR DESCRIPTION
Add support for deploying ETL SQL scripts from an external directory with                                                                                                                                
  automatic fallback to internal classpath mode. Implement transaction                                                                                                                                     
  management with proper rollback on SQL execution failures.                                                                                                                                               
                                                                                                                                                                                                           
  Changes:                                                                                                                                                                                                 
  - Add MambaETLProperties external directory configuration (etlDirectory,                                                                                                                                 
    etlDiscoveryDepth, useExternalEtl, etlDirectoryPath)                                                                                                                                                   
  - Add discoverSqlFiles() to find .sql files in external directory with                                                                                                                                   
    configurable max depth                                                                                                                                                                                 
  - Add deployFromExternalDirectory() to deploy each SQL file with                                                                                                                                         
    success/failure counting                                                                                                                                                                               
  - Implement transaction management with explicit commit/rollback                                                                                                                                         
  - Preserve original exceptions when rollback fails                                                                                                                                                       
  - Handle FileSystemLoopException for symbolic link cycles                                                                                                                                                
  - Protect against path traversal using getCanonicalPath()                                                                                                                                                
  - Distinguish between connection failures and transaction config failures                                                                                                                                
  - Fall back to internal mode on external directory errors (no files,                                                                                                                                     
    permissions, IO errors)